### PR TITLE
terraform cli

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,0 +1,70 @@
+FROM alpine:3.11
+
+LABEL com.kaliop.vendor=Kaliop
+
+WORKDIR /app
+
+ARG ANSIBLE_VERSION=2.9.5
+ARG AWSCLI_VERSION=1.18.0
+ARG PACKER_VERSION=1.5.4
+ARG TERRAFORM_VERSION=0.12.20
+
+RUN  set -x \
+  \
+  && apk add --no-cache --virtual deps \
+    build-base \
+    curl \
+    libffi-dev \
+    openssl-dev \
+    python3-dev \
+    unzip \
+  && apk add --no-cache \
+    bash \
+    docker-cli \
+    libffi \
+    openssl \
+    openssh-client \
+    python3 \
+    sudo \
+  \
+  && curl -SLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && curl -SLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS \
+  && grep linux_amd64 terraform_${TERRAFORM_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && mv terraform /usr/local/bin/ \
+  && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && rm terraform_${TERRAFORM_VERSION}_SHA256SUMS \
+  \
+  && curl -SLO https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \
+  && curl -SLO https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS \
+  && grep linux_amd64 packer_${PACKER_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip packer_${PACKER_VERSION}_linux_amd64.zip \
+  && mv packer /usr/local/bin/ \
+  && rm packer_${PACKER_VERSION}_linux_amd64.zip \
+  && rm packer_${PACKER_VERSION}_SHA256SUMS \
+  \
+  && pip3 install -U \
+    ansible==${ANSIBLE_VERSION} \
+    awscli==${AWSCLI_VERSION} \
+    pip \
+  && rm -rf /root/.cache/pip \
+  \
+  && echo "alias ll='ls -lhF --color'" >> /etc/profile.d/aliases.sh \
+  \
+  && echo 'Set disable_coredump false' > /etc/sudo.conf \
+  && addgroup -g 1000 terraform \
+  && adduser -u 1000 -G terraform -D terraform \
+  && echo "terraform ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+  \
+  && curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz \
+    | tar -C /usr/local/bin -xzf - \
+  && chmod 4755 /usr/local/bin/fixuid \
+  && mkdir -p /etc/fixuid \
+  && printf "user: terraform\ngroup: terraform\npaths:\n  - /app\n" > /etc/fixuid/config.yml \
+  \
+  && apk del deps
+
+USER terraform:terraform
+
+ENTRYPOINT [ "fixuid" ]
+CMD [ "-q", "ash", "-l" ]

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -6,8 +6,12 @@ WORKDIR /app
 
 ARG ANSIBLE_VERSION=2.9.5
 ARG AWSCLI_VERSION=1.18.0
+ARG MOLECULE_VERSION=2.22
 ARG PACKER_VERSION=1.5.4
 ARG TERRAFORM_VERSION=0.12.20
+ARG TESTINFRA_VERSION=4.0.0
+
+ENV LANG=C.UTF-8
 
 RUN  set -x \
   \
@@ -21,6 +25,8 @@ RUN  set -x \
   && apk add --no-cache \
     bash \
     docker-cli \
+    docker-compose \
+    jq \
     libffi \
     openssl \
     openssh-client \
@@ -46,7 +52,9 @@ RUN  set -x \
   && pip3 install -U \
     ansible==${ANSIBLE_VERSION} \
     awscli==${AWSCLI_VERSION} \
+    molecule==${MOLECULE_VERSION} \
     pip \
+    testinfra==${TESTINFRA_VERSION} \
   && rm -rf /root/.cache/pip \
   \
   && echo "alias ll='ls -lhF --color'" >> /etc/profile.d/aliases.sh \

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,6 +4,7 @@ This image provides a cli environment with the following tools installed:
 
 - [awscli](https://github.com/aws/aws-cli)
 - [ansible](https://docs.ansible.com/ansible/latest/index.html)
+- [molecule](https://molecule.readthedocs.io/en/latest/)
 - [packer](https://packer.io/)
 - [terraform](https://www.terraform.io/)
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,54 @@
+# Terraform stack
+
+This image provides a cli environment with the following tools installed:
+
+- [awscli](https://github.com/aws/aws-cli)
+- [ansible](https://docs.ansible.com/ansible/latest/index.html)
+- [packer](https://packer.io/)
+- [terraform](https://www.terraform.io/)
+
+## How to use this image?
+
+When building an infrastructure, we usually pile up steps, each requiring its own tools.
+The first goal of this image is to avoid having to install them on the host system.
+
+Another goal is to make sure all developers will use the same versions.
+
+Typically, this image can be used within your project using docker-compose:
+
+```yaml
+version: "3"
+
+services:
+  cli:
+    image: klabs/terraform:ansible-2.9.5_packer-1.5.4_terraform-0.12.20
+    user: ${UID:-1000}:${GID:-1000}
+    environment:
+      SSH_AUTH_SOCK: /var/run/ssh
+    volumes:
+      - $HOME/.aws:/home/terraform/.aws:ro
+      - $HOME/.aws:/root/.aws:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - $SSH_AUTH_SOCK:/var/run/ssh
+      - .:/app
+``` 
+
+And then run `docker-compose run cli`.
+
+The above example assumes you have `ssh-agent` running.
+It also let you handle your docker daemon from the container.
+The `UID/GID` to use can be set by exporting environment variables or using an [.env file](https://docs.docker.com/compose/env-file/).
+
+## How to build your own version?
+
+```shell
+git clone https://github.com/kaliop/docker-images.git
+cd docker-images/terraform
+
+docker build -t my-image \
+    --build-arg ANSIBLE_VERSION=2.9.5 \
+    --build-arg PACKER_VERSION=1.5.4 \
+    --build-arg TERRAFORM_VERSION=0.12.20 \
+    .
+```
+


### PR DESCRIPTION
A cli container to run terraform stack tools (aws centric for the time-being).

### this image vs `automation`

I first wrote this Dockerfile for my own needs and, when coming to push it to Github, I realized it had quite a lot in common with the `automation` container.

Eventually, this image _should_ be able to superseed the `automation` one, provided it is built with compatible versions.

A few details made me choose not to propose this image as an update for `automation` though. I am really not sure it can be used as a replacement as-is for the time being.